### PR TITLE
Update Java to v11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
       # Speed-up analysis by caching the scanner workspace
       - name: Cache SonarCloud workspace
         uses: actions/cache@v1


### PR DESCRIPTION
Sonarscanner is dependent on Java v11. The example scanner action workflow doesn't work anymore. This fixes that by switching to java v11.