### PR TITLE
fix(BUILD-1287): fix ownership to sonarcloud

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/CODEOWNERS @sonarsource/sonarcloud


### PR DESCRIPTION
Set the team `sonarcloud` as code owner in `.github/CODEOWNERS` file.

A clear unique ownership is required. See [BUILD-1271](https://jira.sonarsource.com/browse/BUILD-1271).
Contact Release Engineering Team for more information.
